### PR TITLE
Bump scaffolding-go, pulling in Go 1.11

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -6,7 +6,7 @@ pkg_version="0.1.0"
 pkg_license=('Chef-MLSA')
 pkg_source=nosuchfile.tar.gz
 pkg_upstream_url="https://github.com/chef/scaffolding-go"
-pkg_deps=core/scaffolding-go/0.1.0/20180806175122
+pkg_deps=core/scaffolding-go
 
 do_build() {
   return 0


### PR DESCRIPTION
This unpins our version of core/scaffolding-go which in turn will pull
in the latest version of core/go.

All of A2 builds and passes tests with this change in place:

https://buildkite.com/chef/chef-a2-master-verify/builds/17409

In the past we had pinned our version of Go to avoid this bug:

https://github.com/golang/go/issues/28065

However, rather than pinning, we should track down any places where
that is still an issue and either make sure those builds either have
gcc available or set GCO_ENABLED=0.

Signed-off-by: Steven Danna <steve@chef.io>