### PR TITLE
Meaningless change to force package rebuild for go 1.11.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ We are giving more flexibility and support to this callback. Now we can build mu
 
 #### `scaffolding_go_before` (override)
 We are overriding this function to link the entire repository inside the studio (`/src`) to the Go workspace so that we can access multiple components, libraries and other files. (Multi-service projects)
+


### PR DESCRIPTION
> Tom Duffield [3:34 PM]
> @dan I’m still seeing chef/scaffolding-go/0.1.0/20181127113359 as latest stable
> Empty changes don’t trigger habitat pkg builds
> you need to actually change a file

Signed-off-by: Daniel DeLeo <dan@chef.io>