### PR TITLE
Use fake chef origin key

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,9 +10,8 @@ steps:
         workdir: /scaffolding-go
   - label: "Build & Test"
     command:
-      - aws-configure chef-cd
-      - AWS_PROFILE=chef-cd hab-origin download-sig-key "\$HAB_ORIGIN"
-      - hab studio -D \$STUDIO_OPTS run "source .studiorc && build_and_test"
+      - hab origin key generate chef
+      - hab studio -D run "source .studiorc && build_and_test"
     env:
       HAB_ORIGIN: chef
       HAB_STUDIO_SUP: false


### PR DESCRIPTION
We don't need the real key to run the verify tests

Signed-off-by: Steven Danna <steve@chef.io>