### PR TITLE
Attempt to build and verify static binaries by default

### DIFF
--- a/lib/scaffolding.sh
+++ b/lib/scaffolding.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-#
+
+#shellcheck disable=SC2034
+#shellcheck disable=SC2154
+
 # Wrapping the core Go scaffolding (Base)
 #
 # The concept of 'Wrapper Scaffolding' doens't exist perse but here we are trying to

--- a/lib/scaffolding_overrides.sh
+++ b/lib/scaffolding_overrides.sh
@@ -45,20 +45,21 @@ scaffolding_go_build() {
 
   # Default to a static build unless the user plan has defined the
   # scaffolding_go_no_static variable.
-  if ! [[ $scaffolding_go_no_static ]]; then
+  if [[ -z $scaffolding_go_no_static ]]; then
     # Go doesn't currently have an "easy" way to enforce static builds. Until the
-    # proposed `-static` flag is added to go-build/go-install we'll need to add
-    # the proper environment variables, ldflags and tags.
+    # proposed `-static` flag is added to go-build/go-install, we'll need to add
+    # the proper environment variables, ldflags and tags to have reasonable
+    # assurance that our build will be static.
     build_line "Configuring static build"
 
     # We assume no CGO here. While we could probably go to some length to leave
     # CGO enabled and use musl, it's probably best for projects that would need
-    # must to override this hook and build it as necessary.
+    # musl to override this hook and build it as necessary.
     go_cmd="CGO_ENABLED=0 $go_cmd"
 
     GO_LDFLAGS="$GO_LDFLAGS -extldflags \"-fno-PIC -static\""
 
-    if ! [[ $scaffolding_go_build_tags ]]; then
+    if [[ -z $scaffolding_go_build_tags ]]; then
       declare -a scaffolding_go_build_tags=()
     fi
     scaffolding_go_build_tags+=('osusergo netgo static_build')
@@ -67,7 +68,7 @@ scaffolding_go_build() {
         echo "$i";
       done | uniq
     )
-    scaffolding_go_build_tags=(unique_tags)
+    scaffolding_go_build_tags=("$unique_tags")
   fi
 
   # Inject Go ldflags

--- a/plan.sh
+++ b/plan.sh
@@ -6,7 +6,10 @@ pkg_version="0.1.0"
 pkg_license=('Chef-MLSA')
 pkg_source=nosuchfile.tar.gz
 pkg_upstream_url="https://github.com/chef/scaffolding-go"
-pkg_deps=core/scaffolding-go
+pkg_deps=(
+  core/scaffolding-go
+  core/grep
+)
 
 do_build() {
   return 0


### PR DESCRIPTION
This change makes `scaffolding_go_build()` attempt to build go binaries
that are statically linked. It does this by completely disabling CGO,
passing static flags to the external linker, and by applying go build
tags that enable the native go backends for the `os/user` and `net`
packages that might otherwise try to dynamically link to `glibc`.

Users of the scaffolding can disable this new functionality by setting
the `scaffolding_go_no_static` variable to a non-empty value in their
plan.

It also creates a default `do_check()` hook that verifies that the any
binaries that are built have no dynamic links. The check can be disabled
using the aforementioned plan variable.