### PR TITLE
pin core/scaffolding-go to version 0.1.0

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -7,7 +7,7 @@ pkg_license=('Chef-MLSA')
 pkg_source=nosuchfile.tar.gz
 pkg_upstream_url="https://github.com/chef/scaffolding-go"
 pkg_deps=(
-  core/scaffolding-go
+  core/scaffolding-go/0.1.0
   core/grep
 )
 


### PR DESCRIPTION
We are not 💯 % ready to use the new version of the `core/scaffolding-go` since
I found a bug that I first need to fix. I am pinning it to the prev version for now but
I will come back to update this wrapper.

Signed-off-by: Salim Afiune <afiune@chef.io>