### PR TITLE
Use core/scaffolding-go 0.2.0

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -7,7 +7,7 @@ pkg_license=('Chef-MLSA')
 pkg_source=nosuchfile.tar.gz
 pkg_upstream_url="https://github.com/chef/scaffolding-go"
 pkg_deps=(
-  core/scaffolding-go/0.1.0
+  core/scaffolding-go
   core/grep
 )
 
@@ -31,4 +31,8 @@ do_download() {
 do_install() {
   install -D -m 0644 "$PLAN_CONTEXT/../lib/scaffolding.sh" "$pkg_prefix/lib/scaffolding.sh"
   install -D -m 0644 "$PLAN_CONTEXT/../lib/scaffolding_overrides.sh" "$pkg_prefix/lib/scaffolding_overrides.sh"
+
+  # libs from core/scaffolding-go
+  install -D -m 0644 "$(pkg_path_for core/scaffolding-go)/lib/go_module.sh" "$pkg_prefix/lib/go_module.sh"
+  install -D -m 0644 "$(pkg_path_for core/scaffolding-go)/lib/gopath_mode.sh" "$pkg_prefix/lib/gopath_mode.sh"
 }


### PR DESCRIPTION
This updates the wrapper scaffolding to use the new `0.2.0` version of the core scaffolding.

Signed-off-by: Salim Afiune <afiune@chef.io>
